### PR TITLE
カレンダーページの機能強化

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,6 +59,8 @@ def get_calendar_data():
         result_data = expenditure_data_manager.get_days_amount_data(date)
     elif type == 'day_detail':
         result_data = expenditure_data_manager.get_day_detail_data(date)
+    elif type == 'day_category_amount':
+        result_data = expenditure_data_manager.get_day_category_amount(date)
     else:
         result_data = {}
     if not result_data:

--- a/main.py
+++ b/main.py
@@ -11,13 +11,11 @@ def index():
 
 @app.route('/input', methods=["POST"])
 def expenses_add():
-
     # 追加するデータの取得
     amount = request.form.get('amount')
     category = request.form.get('category')
     date = request.form.get('date')
-
-    print(amount, category, date)
+    print(f"POST - amount:{amount} category:{category} date:{date}")
 
     # データの追加
     expenditure_data_manager.add_data(amount, category, date)
@@ -47,5 +45,26 @@ def get_data():
 def calendar():
     return render_template('calendar.html')
 
+# カレンダーのデータを取得するAPI
+@app.route('/calendar/data', methods=['GET'])
+def get_calendar_data():
+    # パラメータの取得
+    date = request.args.get('date')
+    type = request.args.get('type')
+    # リクエストパラメータのNoneチェック
+    if date is None:
+        jsonify({'error': 'リクエストパラメータが不正です。'})
+    # データの取得
+    if type == 'days_amount': # 月間の支出データ（日ごとの支出合計）を取得
+        result_data = expenditure_data_manager.get_days_amount_data(date)
+    elif type == 'day_detail':
+        result_data = expenditure_data_manager.get_day_detail_data(date)
+    else:
+        result_data = {}
+    if not result_data:
+        result_data = {}
+    return jsonify(result_data)
+
 if __name__ == '__main__':
-    app.run(debug=True)
+    # Windowsだとdefaultの5000番ポートが使えないので、8888番ポートに変更
+    app.run(port=8888, debug=True)

--- a/modules/expenditure_data_manager.py
+++ b/modules/expenditure_data_manager.py
@@ -103,6 +103,41 @@ def get_day_detail_data(date):
             count += 1
     return result_dict
 
+def get_day_category_amount(date):
+    """
+    指定された日にちの各カテゴリーに対する支出データを取得します。
+
+    Parameters
+    ----------
+    date : str
+        検索する日付。形式は 'YYYY-MM-DD' です。
+
+    Returns
+    -------
+    dict
+        各カテゴリーの支出総額を含む辞書。カテゴリーが存在しない場合は 'その他' として集計します。
+
+    """
+    if not file_path_obj.exists():
+        return {}
+    with open(file_path, 'r') as json_open:
+        j = json.load(json_open)
+    result_dict = defaultdict(int)
+
+    # 引数の変換
+    search_date = datetime.strptime(date, '%Y-%m-%d').date()
+    print(search_date)
+    # カテゴリーのリスト
+    category_list = ['食費', '外食費', '日用品', '交通費', '衣服', '交際費', '趣味']
+
+    for entry in j:
+        entry_date = datetime.strptime(entry["date"], '%Y-%m-%d').date()
+        if entry_date.year == search_date.year and entry_date.month == search_date.month and entry_date.day == search_date.day:
+            category = entry["category"] if entry["category"] in category_list else "その他"
+            result_dict[category] += entry["amount"]
+            
+    return dict(result_dict)
+
 def get_graph_data(date):
     """
     指定された日付の各カテゴリーに対する支出データを取得します。

--- a/modules/expenditure_data_manager.py
+++ b/modules/expenditure_data_manager.py
@@ -6,6 +6,103 @@ from datetime import datetime
 file_path = './modules/balance_of_account.json'
 file_path_obj = pathlib.Path(file_path)
 
+def get_days_amount_data(date):
+    """
+    指定月の支出データ（日ごと）を取得する。
+
+    Parameters
+    ----------
+    date : str
+        検索する日付。形式は 'YYYY-MM-DD' です。
+
+    Returns
+    -------
+    dict
+        日ごとの支出総額を含む辞書。
+
+    """
+    # データの読み込み
+    if not file_path_obj.exists():
+        return {} # データ未追加
+    with open(file_path, 'r') as json_open:
+        j = json.load(json_open)
+    result_dict = defaultdict(int)
+
+    # 引数のパース
+    search_date = datetime.strptime(date, '%Y-%m-%d').date()
+    year = search_date.year
+    month = search_date.month
+
+    # 指定月の日数だけループ
+    for day in range(1, _get_days_of_month(year, month) + 1):
+        # 日ごとの支出合計を計算
+        day_amount = 0
+        for entry in j:
+            entry_date = datetime.strptime(entry["date"], '%Y-%m-%d').date()
+            if entry_date.year == year and entry_date.month == month and entry_date.day == day:
+                day_amount += entry["amount"]
+        # 日ごとの支出合計を辞書に追加
+        result_dict[day] = day_amount
+    return dict(result_dict)
+
+def _get_days_of_month(year, month):
+    """
+    指定された年月の日数を取得します。
+
+    Parameters
+    ----------
+    year : int
+        指定する年。
+    month : int
+        指定する月。
+
+    Returns
+    -------
+    int
+        指定された年月の日数。
+
+    """
+    # 月ごとの日数を格納したリスト
+    days = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    if month == 2: # うるう年
+        if year % 4 == 0 and (year % 100 != 0 or y % 400 == 0):
+            return 29
+    else: # それ以外
+        return days[month - 1]
+
+def get_day_detail_data(date):
+    """
+    指定日の支出データをすべて取得する。
+
+    Parameters
+    ----------
+    date : str
+        検索する日付。形式は 'YYYY-MM-DD' です。
+
+    Returns
+    -------
+    dict
+        指定日の支出データを含む辞書。
+
+    """
+    if not file_path_obj.exists():
+        return {} # データ未追加
+    with open(file_path, 'r') as json_open:
+        j = json.load(json_open)
+    result_dict = defaultdict(int)
+
+    # 引数の変換
+    search_date = datetime.strptime(date, '%Y-%m-%d').date()
+    print(search_date)
+
+    count = 0
+    for entry in j:
+        entry_date = datetime.strptime(entry["date"], '%Y-%m-%d').date()
+        if entry_date.year == search_date.year and entry_date.month == search_date.month and entry_date.day == search_date.day:
+            result_dict[count] = entry
+            count += 1
+    return result_dict
+
 def get_graph_data(date):
     """
     指定された日付の各カテゴリーに対する支出データを取得します。

--- a/static/calendar.css
+++ b/static/calendar.css
@@ -1,12 +1,21 @@
+/*======================================================================
+　カレンダーページCSS
+========================================================================*/
 .wrapper {
     margin: 15px auto;
     max-width: 700px;
   }
+  /* Body メインコンテンツ共通*/
+  .main {
+    max-width: 800px;
+  }
+  /* --------------------*/
+  /* カレンダー部分　　　　*/
+  /* --------------------*/
   .container-calendar {
     background: #ffffff;
-    padding: 15px;
     width: 100%;
-    margin: 0 auto;
+    margin: 10px auto;
     overflow: auto;
   }
   .button-container-calendar button {
@@ -25,25 +34,45 @@
   }
   .table-calendar th,
   .table-calendar td{
-    padding: 10px;
+    padding: 0px;
     border: 1px solid #e2e2e2;
     text-align: center;
     vertical-align: top;
   }
-  .date-picker.selected {
-    font-weight: bold;
-    color: #fff;
+  /* 日付の共通設定 */
+  .date-picker button{ /* ボタン部分(button) */
+    border: none;
+    background: transparent;
+    width: 100%;
+    height: 100%;
+    font-size: 120%;
+    text-align: left;
+  }
+  .date-picker div{ /* 日別の金額表示部分(div) */
+    padding: 5px 0px 0px;
+    text-align: right;
+    font-size: 65%;
+    font-weight: normal;
+    color: black;
+  }
+  /* 選択されている日付 */
+  .date-picker.selected { /* 親部分(td) */
     background: #cc0000;
   }
-  .date-picker.selected span {
-    border-bottom: 2px solid currentColor;
+  .date-picker.selected button { /* ボタン部分(button) */
+    font-weight: bold;
+    color: #fff;
   }
-  /* 日曜 */
-  .date-picker:nth-child(1) {
+  .date-picker.selected div { /* 日別の金額表示部分(div) */
+    font-weight: bold;
+    color: #fff;
+  }
+  /* 日曜日の日付 */
+  .date-picker:nth-child(1) button {
   color: red;
   }
-  /* 土曜 */
-  .date-picker:nth-child(7) {
+  /* 土曜日の日付 */
+  .date-picker:nth-child(7) button {
   color: blue;
   }
   #monthAndYear {
@@ -76,4 +105,18 @@
     border: 1px solid #bfc5c5;
     border-radius: 3px;
     padding: 5px 1em;
+  }
+  /* --------------------*/
+  /* 支出詳細表示部分　　　*/
+  /* --------------------*/
+  .container-detail {
+    background: #ffffff;
+    width: 100%;
+    margin: 10px auto;
+    overflow: auto;
+  }
+
+  #detailTableTitle {
+    text-align: center;
+    margin-top: 0;
   }

--- a/static/calendar.js
+++ b/static/calendar.js
@@ -7,6 +7,8 @@ var selectMonth = document.getElementById("month");
 // 生成する年の範囲設定とその反映
 var createYear = generate_year_range(2000, 2030);
 document.getElementById("year").innerHTML = createYear;
+// カテゴリー設定
+category_list = ['食費', '外食費', '日用品', '交通費', '衣服', '交際費', '趣味', 'その他']
 
 var calendar = document.getElementById("calendar");
 var lang = calendar.getAttribute('data-lang');
@@ -151,7 +153,7 @@ async function showDetail(date, month, year) {
   // 指定日の収支データを取得
   date_str = year + "-" + String(month+1).padStart(2, '0') + "-" + String(date).padStart(2, '0');
   console.log(date_str);
-  const params = {type: "day_detail", date : date_str};
+  const params = {type: "day_category_amount", date : date_str};
   const query = new URLSearchParams(params);
   const response = await fetch (`./calendar/data?${query}`);
   const jsonData = await response.json();
@@ -163,18 +165,22 @@ async function showDetail(date, month, year) {
   var detailBody = document.getElementById("detail-body");
   detailBody.innerHTML = "";
   // 日別データの表示
-  for(var i = 0; i < Object.keys(jsonData).length; i++)
+  for(var i = 0; i < category_list.length; i++)
   {
+    // カテゴリーの金額が0円の場合は表示しない
+    if(typeof jsonData[category_list[i]] === "undefined")
+    {
+      continue;
+    }
     var row = document.createElement("tr");
     // カテゴリー
     cell = document.createElement("td");
-
-    cellText = document.createTextNode(categoryPicker(jsonData[i].category));
+    cellText = document.createTextNode(category_list[i]);
     cell.appendChild(cellText);
     row.appendChild(cell);
     // 金額
     cell = document.createElement("td");
-    cellText = document.createTextNode(jsonData[i].amount + "円");
+    cellText = document.createTextNode(jsonData[category_list[i]] + "円");
     cell.appendChild(cellText);
     row.appendChild(cell);
     // 削除ボタン
@@ -194,22 +200,4 @@ async function showDetail(date, month, year) {
       console.log("Delete:" + date + " " + category + " " + amount);
     });
   });
-}
-
-function categoryPicker(categoryName)
-{
-  // 規定のカテゴリ一覧
-  category_list = ['食費', '外食費', '日用品', '交通費', '衣服', '交際費', '趣味']
-  // category_listに一致しないデータはその他とする
-  isMatch = false;
-  result = "その他";
-  for(var i = 0; i < category_list.length; i++)
-  {
-    if(category_list[i] === categoryName)
-    {
-      result = category_list[i];
-      break;
-    }
-  }
-  return result;
 }

--- a/static/calendar.js
+++ b/static/calendar.js
@@ -1,98 +1,196 @@
+var today = new Date();
+var currentDay = today.getDate();
+var currentMonth = today.getMonth();
+var currentYear = today.getFullYear();
+var selectYear = document.getElementById("year");
+var selectMonth = document.getElementById("month");
+// 生成する年の範囲設定とその反映
+var createYear = generate_year_range(1970, 2200);
+document.getElementById("year").innerHTML = createYear;
+
+var calendar = document.getElementById("calendar");
+var lang = calendar.getAttribute('data-lang');
+
+var months = ["1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"];
+var days = ["日", "月", "火", "水", "木", "金", "土"];
+
+var dayHeader = "<tr>";
+for (day in days) {
+  dayHeader += "<th data-days='" + days[day] + "'>" + days[day] + "</th>";
+}
+dayHeader += "</tr>";
+
+document.getElementById("thead-month").innerHTML = dayHeader;
+
+monthAndYear = document.getElementById("monthAndYear");
+// 生成
+showCalendar(currentMonth, currentYear);
+showDetail(currentDay, currentMonth, currentYear);
+
 function generate_year_range(start, end) {
-    var years = "";
-    for (var year = start; year <= end; year++) {
-        years += "<option value='" + year + "'>" + year + "</option>";
-    }
-    return years;
+  var years = "";
+  for (var year = start; year <= end; year++) {
+    years += "<option value='" + year + "'>" + year + "</option>";
   }
-  
-  var today = new Date();
-  var currentMonth = today.getMonth();
-  var currentYear = today.getFullYear();
-  var selectYear = document.getElementById("year");
-  var selectMonth = document.getElementById("month");
-  
-  var createYear = generate_year_range(1970, 2200);
-  
-  document.getElementById("year").innerHTML = createYear;
-  
-  var calendar = document.getElementById("calendar");
-  var lang = calendar.getAttribute('data-lang');
-  
-  var months = ["1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"];
-  var days = ["日", "月", "火", "水", "木", "金", "土"];
-  
-  var dayHeader = "<tr>";
-  for (day in days) {
-    dayHeader += "<th data-days='" + days[day] + "'>" + days[day] + "</th>";
-  }
-  dayHeader += "</tr>";
-  
-  document.getElementById("thead-month").innerHTML = dayHeader;
-  
-  monthAndYear = document.getElementById("monthAndYear");
+  return years;
+}
+
+function next() {
+  currentYear = (currentMonth === 11) ? currentYear + 1 : currentYear;
+  currentMonth = (currentMonth + 1) % 12;
   showCalendar(currentMonth, currentYear);
-  
-  function next() {
-    currentYear = (currentMonth === 11) ? currentYear + 1 : currentYear;
-    currentMonth = (currentMonth + 1) % 12;
-    showCalendar(currentMonth, currentYear);
-  }
-  
-  function previous() {
-    currentYear = (currentMonth === 0) ? currentYear - 1 : currentYear;
-    currentMonth = (currentMonth === 0) ? 11 : currentMonth - 1;
-    showCalendar(currentMonth, currentYear);
-  }
-  
-  function jump() {
-    currentYear = parseInt(selectYear.value);
-    currentMonth = parseInt(selectMonth.value);
-    showCalendar(currentMonth, currentYear);
-  }
-  
-  function showCalendar(month, year) {
-    var firstDay = (new Date(year, month)).getDay();
-    tbl = document.getElementById("calendar-body");
-    tbl.innerHTML = "";
+}
 
-    monthAndYear.innerHTML = year + "年" + months[month]; // 月と年を逆に表示
-    selectYear.value = year;
-    selectMonth.value = month;
+function previous() {
+  currentYear = (currentMonth === 0) ? currentYear - 1 : currentYear;
+  currentMonth = (currentMonth === 0) ? 11 : currentMonth - 1;
+  showCalendar(currentMonth, currentYear);
+}
 
-    var date = 1;
-    for (var i = 0; i < 6; i++) {
-        var row = document.createElement("tr");
+function jump() {
+  currentYear = parseInt(selectYear.value);
+  currentMonth = parseInt(selectMonth.value);
+  showCalendar(currentMonth, currentYear);
+}
 
-        for (var j = 0; j < 7; j++) {
-            if (i === 0 && j < firstDay) {
-                cell = document.createElement("td");
-                cellText = document.createTextNode("");
-                cell.appendChild(cellText);
-                row.appendChild(cell);
-            } else if (date > daysInMonth(month, year)) {
-                break;
-            } else {
-                cell = document.createElement("td");
-                cell.setAttribute("data-date", date);
-                cell.setAttribute("data-month", month + 1);
-                cell.setAttribute("data-year", year);
-                cell.setAttribute("data-month_name", months[month]);
-                cell.className = "date-picker";
-                cell.innerHTML = "<span>" + date + "</span>";
+async function showCalendar(month, year) {
+  console.log("showCalendar:" + year + "/" + (month+1));
+  // その月の収支データを取得
+  date_str = year + "-" + String(month+1).padStart(2, '0') + "-01";
+  const params = {type: "days_amount", date : date_str};
+  const query = new URLSearchParams(params);
+  const response = await fetch (`./calendar/data?${query}`);
+  const jsonData = await response.json();
+  var firstDay = (new Date(year, month)).getDay();
+  tbl = document.getElementById("calendar-body");
+  tbl.innerHTML = "";
 
-                if (date === today.getDate() && year === today.getFullYear() && month === today.getMonth()) {
-                    cell.className = "date-picker selected";
-                }
-                row.appendChild(cell);
-                date++;
-            }
+  monthAndYear.innerHTML = year + "年" + months[month]; // 月と年を逆に表示
+  selectYear.value = year;
+  selectMonth.value = month;
+
+  var date = 1;
+  for (var i = 0; i < 6; i++) {
+    var row = document.createElement("tr");
+
+    for (var j = 0; j < 7; j++) {
+      if (i === 0 && j < firstDay) {
+        cell = document.createElement("td");
+        cellText = document.createTextNode("");
+        cell.appendChild(cellText);
+        row.appendChild(cell);
+      } else if (date > daysInMonth(month, year)) {
+        break;
+      } else {
+        cell = document.createElement("td");
+        cell.setAttribute("data-date", date);
+        cell.setAttribute("data-month", month + 1);
+        cell.setAttribute("data-year", year);
+        cell.setAttribute("data-month_name", months[month]);
+        cell.className = "date-picker";
+        // 各日付のデータを表示
+        if(Object.keys(jsonData).length === 0 || jsonData[date] === 0)
+        {
+          // 月別データがない場合
+          iTEXT = "データなし";
         }
+        else
+        {
+          // 日別データがある場合
+          iTEXT = jsonData[date] + "円";
+        }
+        cell.innerHTML = "<button type='button' id='date-cell-button'>" + date + "<div>" +  iTEXT + "</div></button>";
 
-        tbl.appendChild(row);
+        if (date === today.getDate() && year === today.getFullYear() && month === today.getMonth()) {
+          cell.className = "date-picker selected";
+        }
+        row.appendChild(cell);
+        date++;
+      }
     }
-  }
 
-  function daysInMonth(iMonth, iYear) {
-    return 32 - new Date(iYear, iMonth, 32).getDate();
+    tbl.appendChild(row);
   }
+  // イベントリスナーの追加
+  const buttons = document.querySelectorAll('#date-cell-button');
+  buttons.forEach(button => {
+    button.addEventListener('click', () => {
+      const date = parseInt(button.parentElement.getAttribute("data-date"));
+      const month = parseInt(button.parentElement.getAttribute("data-month"))
+      const year = parseInt(button.parentElement.getAttribute("data-year"));
+      // クリックされた日付のデータを表示
+      console.log("Selected:" + year + "/" + month + "/" + date + "");
+      // 選択状態の更新
+      updateSelectedDate(date);
+      // 日別データの表示
+      showDetail(date, month-1, year);
+    });
+  });
+}
+
+function daysInMonth(iMonth, iYear) {
+  return 32 - new Date(iYear, iMonth, 32).getDate();
+}
+
+function updateSelectedDate(iDay) {
+  // Selected クラス属性がついた要素を取得
+  var selected = document.getElementsByClassName("selected");
+  if(selected.length !== 0) // Selected クラス属性がついた要素がある場合
+  {
+    // Selected クラス属性を削除
+    selected[0].classList.remove("selected");
+  }
+  // data-date属性がiDayの要素を取得
+  var nowSelected = document.querySelector("[data-date='" + iDay + "']");
+  // Selected クラス属性を追加
+  nowSelected.classList.add("selected");
+}
+
+async function showDetail(date, month, year) {
+  console.log("showDetail:" + year + "/" + (month+1) + "/" + date);
+  // 指定日の収支データを取得
+  date_str = year + "-" + String(month+1).padStart(2, '0') + "-" + String(date).padStart(2, '0');
+  console.log(date_str);
+  const params = {type: "day_detail", date : date_str};
+  const query = new URLSearchParams(params);
+  const response = await fetch (`./calendar/data?${query}`);
+  const jsonData = await response.json();
+  console.log(jsonData);
+  // タイトル更新
+  var detailTitle = document.getElementById("detailTableTitle");
+  detailTitle.innerHTML = year + "年" + (month+1) + "月" + date + "日の収支詳細データ";
+  // テーブル更新
+  var detailBody = document.getElementById("detail-body");
+  detailBody.innerHTML = "";
+  // 日別データの表示
+  for(var i = 0; i < Object.keys(jsonData).length; i++)
+  {
+    var row = document.createElement("tr");
+    // カテゴリー
+    cell = document.createElement("td");
+    cellText = document.createTextNode(jsonData[i].category);
+    cell.appendChild(cellText);
+    row.appendChild(cell);
+    // 金額
+    cell = document.createElement("td");
+    cellText = document.createTextNode(jsonData[i].amount + "円");
+    cell.appendChild(cellText);
+    row.appendChild(cell);
+    // 削除ボタン
+    cell = document.createElement("td");
+    cell.innerHTML = "<button type='button' id='delete-button'>削除</button>";
+    row.appendChild(cell);
+    detailBody.appendChild(row);
+  }
+  // イベントリスナーの追加
+  const buttons = document.querySelectorAll('#delete-button');
+  buttons.forEach(button => {
+    button.addEventListener('click', () => {
+      const date = button.parentElement.parentElement.children[0].innerText;
+      const category = button.parentElement.parentElement.children[1].innerText;
+      const amount = button.parentElement.parentElement.children[2].innerText;
+      // クリックされた日付のデータを表示
+      console.log("Delete:" + date + " " + category + " " + amount);
+    });
+  });
+}

--- a/static/calendar.js
+++ b/static/calendar.js
@@ -180,7 +180,7 @@ async function showDetail(date, month, year) {
     //cell = document.createElement("td");
     //cell.innerHTML = "<button type='button' id='delete-button'>削除</button>";
     //row.appendChild(cell);
-    //detailBody.appendChild(row);
+    detailBody.appendChild(row);
   }
   // イベントリスナーの追加
   const buttons = document.querySelectorAll('#delete-button');

--- a/static/calendar.js
+++ b/static/calendar.js
@@ -5,7 +5,7 @@ var currentYear = today.getFullYear();
 var selectYear = document.getElementById("year");
 var selectMonth = document.getElementById("month");
 // 生成する年の範囲設定とその反映
-var createYear = generate_year_range(1970, 2200);
+var createYear = generate_year_range(2000, 2030);
 document.getElementById("year").innerHTML = createYear;
 
 var calendar = document.getElementById("calendar");
@@ -92,7 +92,7 @@ async function showCalendar(month, year) {
         if(Object.keys(jsonData).length === 0 || jsonData[date] === 0)
         {
           // 月別データがない場合
-          iTEXT = "データなし";
+          iTEXT = "";
         }
         else
         {
@@ -177,10 +177,10 @@ async function showDetail(date, month, year) {
     cell.appendChild(cellText);
     row.appendChild(cell);
     // 削除ボタン
-    cell = document.createElement("td");
-    cell.innerHTML = "<button type='button' id='delete-button'>削除</button>";
-    row.appendChild(cell);
-    detailBody.appendChild(row);
+    //cell = document.createElement("td");
+    //cell.innerHTML = "<button type='button' id='delete-button'>削除</button>";
+    //row.appendChild(cell);
+    //detailBody.appendChild(row);
   }
   // イベントリスナーの追加
   const buttons = document.querySelectorAll('#delete-button');

--- a/static/calendar.js
+++ b/static/calendar.js
@@ -92,7 +92,7 @@ async function showCalendar(month, year) {
         if(Object.keys(jsonData).length === 0 || jsonData[date] === 0)
         {
           // 月別データがない場合
-          iTEXT = "";
+          iTEXT = "　";
         }
         else
         {

--- a/static/calendar.js
+++ b/static/calendar.js
@@ -168,7 +168,8 @@ async function showDetail(date, month, year) {
     var row = document.createElement("tr");
     // カテゴリー
     cell = document.createElement("td");
-    cellText = document.createTextNode(jsonData[i].category);
+
+    cellText = document.createTextNode(categoryPicker(jsonData[i].category));
     cell.appendChild(cellText);
     row.appendChild(cell);
     // 金額
@@ -193,4 +194,22 @@ async function showDetail(date, month, year) {
       console.log("Delete:" + date + " " + category + " " + amount);
     });
   });
+}
+
+function categoryPicker(categoryName)
+{
+  // 規定のカテゴリ一覧
+  category_list = ['食費', '外食費', '日用品', '交通費', '衣服', '交際費', '趣味']
+  // category_listに一致しないデータはその他とする
+  isMatch = false;
+  result = "その他";
+  for(var i = 0; i < category_list.length; i++)
+  {
+    if(category_list[i] === categoryName)
+    {
+      result = category_list[i];
+      break;
+    }
+  }
+  return result;
 }

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -58,7 +58,6 @@
         <tr>
           <th>カテゴリ</th>
           <th>金額</th>
-          <th>削除</th>
         </tr>
       </thead>
       <tbody id="detail-body">

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
   <title>カレンダーページ</title>
   <!-- カレンダーのスタイルシート -->
   <link rel="stylesheet" href="../static/calendar.css">
@@ -10,8 +11,15 @@
   <link rel="stylesheet" href="../static/style.css">
   </head>
 <body>
+  <!-- Header -->
+  <div class="header">
+    <a href="/">入力ページ</a>
+    <a href="/graph">グラフページ</a>
+    <a href="/calendar">カレンダーページ</a>
+  </div>
+
   <!-- Body カレンダー部 -->
-  <div class="container-calendar">
+  <div class="container-calendar main">
     <h4 id="monthAndYear"></h4>
     <div class="button-container-calendar">
       <button id="previous" onclick="previous()">‹</button>
@@ -41,14 +49,29 @@
       </select>
     </div>
   </div>
-  <script src="../static/calendar.js"></script>
-  
-  <!-- Header -->
-  <div class="header">
-    <a href="/">入力ページ</a>
-    <a href="/graph">グラフページ</a>
-    <a href="/calendar">カレンダーページ</a>
+
+  <!-- Body 支出詳細表示部 -->
+  <div class="container-detail main">
+    <h4 id="detailTableTitle">YYYY年MM月DD日の詳細</h4>
+    <table class="table-detail">
+      <thead id="thead-header">
+        <tr>
+          <th>カテゴリ</th>
+          <th>金額</th>
+          <th>削除</th>
+        </tr>
+      </thead>
+      <tbody id="detail-body">
+        <!-- ここに支出詳細が入る -->
+        <tr>
+          <td id="detail-data-message">&nbsp;<!-- メッセージ表示用　データなしの場合にその旨を表示--></td>
+          <td><!-- --></td>
+          <td><!-- --></td>
+        </tr>
+      </tbody>
+    </table>
   </div>
+  <script src="../static/calendar.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## やったこと

* -main.py変更箇所
* expenses_add関数のデバック表示を修正、より分かりやすく。
* カレンダー表示用のAPIを実装
* flask起動時のパラメータを追加 port番号をdefaultの5000番から8888番に変更。
* 
* -expenditure_data_manager.py変更箇所
* get_days_amount_data関数の追加　指定月の支出データ（日ごと）を取得できるように
* get_day_detail_data関数の追加　指定日の支出データをすべて取得できるように
* _get_days_of_month関数の追加　指定月の日数を返す
* 
* -calendar.css変更箇所
* 全体的なレイアウトの修正
* 一部レイアウト修正に必要な個所についてコメントを追加
* 
* calendar.js変更箇所
* コードの順序変更　関数をすべて下側に
* showDetail関数の追加　支出詳細の表示を行う
* showCalendar関数の追加　カレンダーレイアウトの変更
* updateSelectedDate関数の追加　特定の日をカレンダーから選択できるようにする関数
* 
* calendar.html変更箇所
*  支出詳細表示部追加
* Headerをページ上部へ

## やらないこと

* 収支詳細データのカテゴリ項目に関して、サーバーに保存されている生データを出力しているため、本来Otherに分類されるはずのカテゴリが表示される問題あり。入力ページをプルダウンにするか、表示前に加工。見た目と利便性を考えるならプルダウンにして制限すべき。
* 日別の詳細支出データ表示箇所のレイアウト適用
* jqueryの読み込み箇所の削除ー＞結局使うのやめて、消去し忘れた
* データの削除処理（ボタンのみ実装済み）　データ保存形式を変更する必要あり。しなくてもできなくはないが、データが重複している場合に選択していない項目まで消えてしまうため実装保留　データに固有のID値を付与すれば解決する。

## できるようになること（ユーザ目線）

* Windows環境でも実行可能に。
* カレンダーにて、日別の支出合計と支出詳細を確認可能に。

## できなくなること（ユーザ目線）

* port5000番での起動

## 動作確認

* 適当にデータ入力。動作確認。パッと見た感じ、動く。

## その他

*短時間で弄ったんで潜在的なバグがあるかも。プルリクに書き抜けてるところがあるかもしれないですが、ご容赦ください。
*今日の日にちに戻るボタンを追加してもいいかもしれないと思った。
*木曜日余裕があればやるってことで。
